### PR TITLE
Handling null identity

### DIFF
--- a/45/BrockAllen.CookieTempData/CookieTempDataProvider.cs
+++ b/45/BrockAllen.CookieTempData/CookieTempDataProvider.cs
@@ -96,8 +96,8 @@ namespace BrockAllen.CookieTempData
 
         string GetMachineKeyPurpose(HttpContextBase ctx)
         {
-            if (!ctx.User.Identity.IsAuthenticated) return GetAnonMachineKeyPurpose();
-            return String.Format(MachineKeyPurpose, ctx.User.Identity.Name);
+            if (ctx.User.Identity == null || !ctx.User.Identity.IsAuthenticated) return GetAnonMachineKeyPurpose();
+            return String.Format(MachineKeyPurpose, ctx.User.Identity == null ? "" : ctx.User.Identity.Name);
         }
         
         string GetMachineKeyPurposeFromPrefix(string prefix, HttpContextBase ctx)


### PR DESCRIPTION
Currently the TempDataProvider doesn't allow HttpContext.User.Identity
to be null and throws a NullReferenceException when it occurs. I added a
null check to avoid this.
